### PR TITLE
fix: define privilege object schema for create and update tools

### DIFF
--- a/lib/tools/privileges.js
+++ b/lib/tools/privileges.js
@@ -54,7 +54,14 @@ export async function createPrivilege(api, args) {
     throw new Error('name is required');
   }
 
-  return await api.post('/api/1/privileges', args);
+  if (!args.privilege) {
+    throw new Error('privilege object is required');
+  }
+
+  const body = { name: args.name, privilege: args.privilege };
+  if (args.description) body.description = args.description;
+
+  return await api.post('/api/1/privileges', body);
 }
 
 /**
@@ -69,11 +76,12 @@ export async function updatePrivilege(api, args) {
     throw new Error('privilege_id is required');
   }
 
-  const privilegeId = args.privilege_id;
-  const updateData = { ...args };
-  delete updateData.privilege_id;
+  const body = {};
+  if (args.name) body.name = args.name;
+  if (args.description !== undefined) body.description = args.description;
+  if (args.privilege) body.privilege = args.privilege;
 
-  return await api.put(`/api/1/privileges/${privilegeId}`, updateData);
+  return await api.put(`/api/1/privileges/${args.privilege_id}`, body);
 }
 
 /**
@@ -233,27 +241,91 @@ export const tools = [
   },
   {
     name: 'create_privilege',
-    description: 'Create a new privilege object that defines actions on OneLogin resources. IMPORTANT: Privileges don\'t grant user access - they describe what actions can be performed. Assign privilege to user/role to grant access. Requires policy statement with Version="2018-05-18", Statement array with Effect="Allow", Action (e.g., "users:List"), and Scope (e.g., "*" or "apps/1234"). Use wildcard "*" for super user privileges. Don\'t mix classes in Action array. IMPORTANT: Requires Delegated Administration subscription. Returns created privilege ID and x-request-id (API v1 - Rate Limited).',
+    description: 'Create a new privilege that defines actions on OneLogin resources. Privileges don\'t grant access until assigned to a user or role. Use wildcard "*" for super user privileges. Don\'t mix resource classes in the Action array (e.g., don\'t combine users: and apps: actions in one statement). Requires Delegated Administration subscription. Returns created privilege ID and x-request-id (API v1 - Rate Limited).',
     inputSchema: {
       type: 'object',
       properties: {
-        name: { type: 'string', description: 'Privilege name' }
+        name: { type: 'string', description: 'Privilege name (e.g., "User Helpdesk")' },
+        description: { type: 'string', description: 'Human-readable description of the privilege' },
+        privilege: {
+          type: 'object',
+          description: 'The authorization policy definition',
+          properties: {
+            Version: { type: 'string', description: 'Policy version, must be "2018-05-18"', enum: ['2018-05-18'] },
+            Statement: {
+              type: 'array',
+              description: 'Array of permission statements',
+              items: {
+                type: 'object',
+                properties: {
+                  Effect: { type: 'string', description: 'Must be "Allow"', enum: ['Allow'] },
+                  Action: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    description: 'Actions to allow (e.g., ["users:List", "users:Get", "users:Unlock"] or ["*"] for all)'
+                  },
+                  Scope: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    description: 'Resource scope (e.g., ["*"] for all, or ["apps/1234"] for specific resources)'
+                  }
+                },
+                required: ['Effect', 'Action', 'Scope'],
+                additionalProperties: false
+              }
+            }
+          },
+          required: ['Version', 'Statement'],
+          additionalProperties: false
+        }
       },
-      required: ['name'],
-      additionalProperties: true
+      required: ['name', 'privilege'],
+      additionalProperties: false
     }
   },
   {
     name: 'update_privilege',
-    description: 'Update an existing privilege definition. IMPORTANT: Requires Delegated Administration subscription. Can update name, description, and policy statement. Returns updated privilege data and x-request-id (API v1 - Rate Limited).',
+    description: 'Update an existing privilege definition. Can update name, description, and/or the policy statement. Requires Delegated Administration subscription. Returns updated privilege data and x-request-id (API v1 - Rate Limited).',
     inputSchema: {
       type: 'object',
       properties: {
         privilege_id: { type: 'string', description: 'The OneLogin privilege ID to update' },
-        name: { type: 'string', description: 'New privilege name' }
+        name: { type: 'string', description: 'New privilege name' },
+        description: { type: 'string', description: 'New description' },
+        privilege: {
+          type: 'object',
+          description: 'Updated authorization policy definition',
+          properties: {
+            Version: { type: 'string', description: 'Policy version, must be "2018-05-18"', enum: ['2018-05-18'] },
+            Statement: {
+              type: 'array',
+              description: 'Array of permission statements',
+              items: {
+                type: 'object',
+                properties: {
+                  Effect: { type: 'string', description: 'Must be "Allow"', enum: ['Allow'] },
+                  Action: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    description: 'Actions to allow (e.g., ["users:List", "users:Get"] or ["*"] for all)'
+                  },
+                  Scope: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    description: 'Resource scope (e.g., ["*"] for all, or ["apps/1234"] for specific resources)'
+                  }
+                },
+                required: ['Effect', 'Action', 'Scope'],
+                additionalProperties: false
+              }
+            }
+          },
+          required: ['Version', 'Statement'],
+          additionalProperties: false
+        }
       },
       required: ['privilege_id'],
-      additionalProperties: true
+      additionalProperties: false
     }
   },
   {


### PR DESCRIPTION
## Summary

- Fully define the `privilege` nested object schema (Version, Statement with Effect/Action/Scope) in both `create_privilege` and `update_privilege` tool definitions
- Add missing `description` field to both schemas
- Replace `additionalProperties: true` with `additionalProperties: false` on all objects
- Explicitly construct request bodies in handlers instead of passing raw args through

## Root cause

The `create_privilege` and `update_privilege` schemas only declared `name` as a property with `additionalProperties: true`. The critical `privilege` object -- with its nested `Version`/`Statement`/`Effect`/`Action`/`Scope` structure -- was only described in the tool description text. MCP clients (LLMs) had to guess the structure, and different model versions interpreted it differently, leading to malformed API requests.

**Before:**
```javascript
inputSchema: {
  type: 'object',
  properties: {
    name: { type: 'string', description: 'Privilege name' }
  },
  required: ['name'],
  additionalProperties: true  // LLM has to guess everything else
}
```

**After:**
```javascript
inputSchema: {
  type: 'object',
  properties: {
    name: { type: 'string', description: '...' },
    description: { type: 'string', description: '...' },
    privilege: {
      type: 'object',
      properties: {
        Version: { type: 'string', enum: ['2018-05-18'] },
        Statement: {
          type: 'array',
          items: {
            type: 'object',
            properties: {
              Effect: { type: 'string', enum: ['Allow'] },
              Action: { type: 'array', items: { type: 'string' } },
              Scope: { type: 'array', items: { type: 'string' } }
            },
            required: ['Effect', 'Action', 'Scope'],
            additionalProperties: false
          }
        }
      },
      required: ['Version', 'Statement'],
      additionalProperties: false
    }
  },
  required: ['name', 'privilege'],
  additionalProperties: false
}
```

`delete_privilege` was not affected (it only needs `privilege_id`, which was already properly defined).

## Test plan

- [ ] Create a new privilege via MCP and verify the API accepts the request body
- [ ] Update an existing privilege via MCP and verify the API accepts the request body
- [ ] Verify delete still works (unchanged)
- [ ] Verify list and get still work (unchanged)

Fixes #33