### PR TITLE
fix: use api/1 for user role assignment endpoints

### DIFF
--- a/lib/tools/roles.js
+++ b/lib/tools/roles.js
@@ -1,6 +1,6 @@
 /**
  * OneLogin Role Management Tools
- * API Reference: /api/2/roles and /api/2/users/{user_id}/add_roles
+ * API Reference: /api/2/roles and /api/1/users/{user_id}/add_roles|remove_roles
  */
 
 /**
@@ -49,7 +49,8 @@ export async function getRole(api, args) {
 
 /**
  * Assign roles to a user
- * Reference: PUT /api/2/users/{user_id}/add_roles
+ * Reference: PUT /api/1/users/{user_id}/add_roles
+ * Note: Role assignment lives in api/1, not api/2
  * @param {OneLoginApi} api
  * @param {Object} args - {user_id: number, role_ids: number[]}
  * @returns {Promise<Object>}
@@ -63,14 +64,15 @@ export async function assignRoleToUser(api, args) {
     throw new Error('role_ids array is required');
   }
 
-  return await api.put(`/api/2/users/${args.user_id}/add_roles`, {
+  return await api.put(`/api/1/users/${args.user_id}/add_roles`, {
     role_id_array: args.role_ids
   });
 }
 
 /**
  * Remove roles from a user
- * Reference: PUT /api/2/users/{user_id}/remove_roles
+ * Reference: PUT /api/1/users/{user_id}/remove_roles
+ * Note: Role assignment lives in api/1, not api/2
  * @param {OneLoginApi} api
  * @param {Object} args - {user_id: number, role_ids: number[]}
  * @returns {Promise<Object>}
@@ -84,7 +86,7 @@ export async function removeRoleFromUser(api, args) {
     throw new Error('role_ids array is required');
   }
 
-  return await api.put(`/api/2/users/${args.user_id}/remove_roles`, {
+  return await api.put(`/api/1/users/${args.user_id}/remove_roles`, {
     role_id_array: args.role_ids
   });
 }


### PR DESCRIPTION
## Summary

- Change `assign_role_to_user` from `PUT /api/2/users/:id/add_roles` to `PUT /api/1/users/:id/add_roles`
- Change `remove_role_from_user` from `PUT /api/2/users/:id/remove_roles` to `PUT /api/1/users/:id/remove_roles`

## Root cause

The OneLogin API splits role operations across two API versions:
- **Role CRUD** lives at `/api/2/roles/*` (list, get, create, update, delete, apps, users, admins)
- **User-role assignment** lives at `/api/1/users/:id/add_roles` and `/api/1/users/:id/remove_roles`

The MCP incorrectly assumed both were under `/api/2`. But `add_roles` and `remove_roles` were never added to the api/2 user routes -- confirmed by `api2_routes.rb` where users have nested routes for `apps`, `privileges`, and `delegated_privileges` but NOT `add_roles`/`remove_roles`.

The 401 error occurred because the route didn't match any endpoint, and the auth middleware returns 401 for unmatched authenticated routes.

Confirmed against [OneLogin API docs](https://developers.onelogin.com/api-docs/1/users/assign-role-to-user): `PUT /api/1/users/:id/add_roles`.

## Test plan

- [ ] Assign a role to a user via MCP and verify it succeeds (no more 401)
- [ ] Remove a role from a user via MCP and verify it succeeds
- [ ] Verify role CRUD operations still work at `/api/2/roles` (unchanged)

Fixes #34