### PR TITLE
fix: define configuration object in create/update app schemas

### DIFF
--- a/lib/tools/apps.js
+++ b/lib/tools/apps.js
@@ -61,11 +61,14 @@ export async function updateApp(api, args) {
     throw new Error('app_id is required');
   }
 
-  const appId = args.app_id;
-  const updateData = { ...args };
-  delete updateData.app_id;
+  const body = {};
+  const fields = ['name', 'description', 'notes', 'visible', 'policy_id',
+    'allow_assumed_signin', 'tab_id', 'configuration', 'sso', 'provisioning'];
+  for (const field of fields) {
+    if (args[field] !== undefined) body[field] = args[field];
+  }
 
-  return await api.put(`/api/2/apps/${appId}`, updateData);
+  return await api.put(`/api/2/apps/${args.app_id}`, body);
 }
 
 /**
@@ -76,7 +79,21 @@ export async function updateApp(api, args) {
  * @returns {Promise<Object>}
  */
 export async function createApp(api, args) {
-  return await api.post('/api/2/apps', args);
+  if (!args.connector_id) {
+    throw new Error('connector_id is required');
+  }
+  if (!args.name) {
+    throw new Error('name is required');
+  }
+
+  const body = {};
+  const fields = ['connector_id', 'name', 'description', 'notes', 'visible', 'policy_id',
+    'allow_assumed_signin', 'tab_id', 'configuration', 'sso', 'provisioning'];
+  for (const field of fields) {
+    if (args[field] !== undefined) body[field] = args[field];
+  }
+
+  return await api.post('/api/2/apps', body);
 }
 
 /**
@@ -323,30 +340,70 @@ export const tools = [
   },
   {
     name: 'update_app',
-    description: 'Update an existing OneLogin app. Returns updated app data and x-request-id.',
+    description: 'Update an existing OneLogin app. Supports partial updates - only provide the fields you want to change. For OIDC apps, use the configuration object to set login_url, redirect_uri, etc. For a complete list of configuration fields for a given app type, use get_app on an existing app with the same connector. Returns updated app data and x-request-id.',
     inputSchema: {
       type: 'object',
       properties: {
         app_id: { type: 'number', description: 'The OneLogin app ID to update' },
-        name: { type: 'string', description: 'New app name' },
-        description: { type: 'string', description: 'New app description' },
-        notes: { type: 'string', description: 'New app notes' }
+        name: { type: 'string', description: 'App name' },
+        description: { type: 'string', description: 'App description' },
+        notes: { type: 'string', description: 'App notes' },
+        visible: { type: 'boolean', description: 'Whether app is visible in user portal' },
+        policy_id: { type: 'number', description: 'Security policy ID to assign' },
+        allow_assumed_signin: { type: 'boolean', description: 'Allow assumed sign-in' },
+        tab_id: { type: 'number', description: 'Tab ID for portal organization' },
+        configuration: {
+          type: 'object',
+          description: 'App-specific configuration (varies by connector type). OIDC apps: login_url, redirect_uri, access_token_expiration_minutes, refresh_token_expiration_minutes, token_endpoint_auth_method, oidc_application_type. SAML apps: signature_algorithm, certificate_id. Use get_app on a same-connector app to see all available fields.',
+          additionalProperties: true
+        },
+        sso: {
+          type: 'object',
+          description: 'SSO settings (varies by connector type). May include certificate, issuer, metadata_url, etc.',
+          additionalProperties: true
+        },
+        provisioning: {
+          type: 'object',
+          description: 'Provisioning settings (varies by connector type)',
+          additionalProperties: true
+        }
       },
       required: ['app_id'],
-      additionalProperties: true
+      additionalProperties: false
     }
   },
   {
     name: 'create_app',
-    description: 'Create a new app based on a OneLogin connector. Minimum required: connector_id and name. If connector allows (check allows_new_parameters via List Connectors), custom parameters can be added during creation - any parameter not matching existing parameters will be auto-created. For complete app configuration options, do a get_app request on an app with the same connector. For OpenId Connect apps: response includes client_id and client_secret. Returns created app data and x-request-id.',
+    description: 'Create a new app based on a OneLogin connector. Minimum required: connector_id and name. For OIDC apps, use configuration to set login_url, redirect_uri, etc. For complete configuration options, use get_app on an existing app with the same connector. For OpenId Connect apps: response includes client_id and client_secret. Returns created app data and x-request-id.',
     inputSchema: {
       type: 'object',
       properties: {
-        connector_id: { type: 'number', description: 'Connector ID for the app type' },
-        name: { type: 'string', description: 'App name' },
-        description: { type: 'string', description: 'App description' }
+        connector_id: { type: 'number', description: 'Connector ID for the app type (required)' },
+        name: { type: 'string', description: 'App name (required)' },
+        description: { type: 'string', description: 'App description' },
+        notes: { type: 'string', description: 'App notes' },
+        visible: { type: 'boolean', description: 'Whether app is visible in user portal' },
+        policy_id: { type: 'number', description: 'Security policy ID to assign' },
+        allow_assumed_signin: { type: 'boolean', description: 'Allow assumed sign-in' },
+        tab_id: { type: 'number', description: 'Tab ID for portal organization' },
+        configuration: {
+          type: 'object',
+          description: 'App-specific configuration (varies by connector type). OIDC apps: login_url, redirect_uri, access_token_expiration_minutes, refresh_token_expiration_minutes, token_endpoint_auth_method, oidc_application_type. SAML apps: signature_algorithm, certificate_id. Use get_app on a same-connector app to see all available fields.',
+          additionalProperties: true
+        },
+        sso: {
+          type: 'object',
+          description: 'SSO settings (varies by connector type)',
+          additionalProperties: true
+        },
+        provisioning: {
+          type: 'object',
+          description: 'Provisioning settings (varies by connector type)',
+          additionalProperties: true
+        }
       },
-      additionalProperties: true
+      required: ['connector_id', 'name'],
+      additionalProperties: false
     }
   },
   {


### PR DESCRIPTION
## Summary

- Add `configuration`, `sso`, and `provisioning` objects to `create_app` and `update_app` input schemas
- Add other missing top-level fields: `visible`, `policy_id`, `allow_assumed_signin`, `tab_id`
- Replace `additionalProperties: true` on root with `additionalProperties: false`
- Keep `additionalProperties: true` on connector-specific nested objects (configuration varies by connector type)
- Explicitly construct request bodies in handlers
- Make `connector_id` and `name` required for `create_app`

## Root cause

Same pattern as PR 37 (privileges). The `create_app` and `update_app` schemas had `additionalProperties: true` but didn't define `configuration` as a property. The MCP client (LLM) had no way to know it could include a `configuration` object with fields like `login_url` and `redirect_uri` for OIDC apps.

**Before:**
```javascript
properties: {
  app_id: { ... },
  name: { ... },
  description: { ... },
  notes: { ... }
},
additionalProperties: true  // LLM doesn't know about configuration
```

**After:**
```javascript
properties: {
  app_id: { ... },
  name: { ... },
  description: { ... },
  notes: { ... },
  visible: { ... },
  policy_id: { ... },
  configuration: {
    type: 'object',
    description: 'OIDC: login_url, redirect_uri, ... SAML: signature_algorithm, ...',
    additionalProperties: true  // connector-specific fields
  },
  sso: { ... },
  provisioning: { ... }
},
additionalProperties: false
```

The `configuration` object uses `additionalProperties: true` internally because its fields vary per connector type (OIDC, SAML, etc.). The description lists common OIDC and SAML fields to guide the LLM.

## Test plan

- [ ] Create an OIDC app with `configuration: { login_url: "...", redirect_uri: "..." }` and verify it's set
- [ ] Update an existing app's `configuration` and verify the change takes effect
- [ ] Verify get_app, delete_app, list_apps still work (unchanged)

Fixes #35