### PR TITLE
000: Fix update_app_rule partial update (422 error)

### DIFF
--- a/lib/tools/apps.js
+++ b/lib/tools/apps.js
@@ -232,9 +232,16 @@ export async function updateAppRule(api, args) {
 
   const appId = args.app_id;
   const ruleId = args.rule_id;
-  const updateData = { ...args };
-  delete updateData.app_id;
-  delete updateData.rule_id;
+
+  // PUT requires a complete rule body, so fetch the existing rule first
+  // and merge the caller's changes on top of it.
+  const existing = await api.get(`/api/2/apps/${appId}/rules/${ruleId}`);
+
+  const changes = { ...args };
+  delete changes.app_id;
+  delete changes.rule_id;
+
+  const updateData = { ...existing, ...changes };
 
   return await api.put(`/api/2/apps/${appId}/rules/${ruleId}`, updateData);
 }


### PR DESCRIPTION
## Problem

`update_app_rule` was sending only the caller-provided fields to `PUT /api/2/apps/{id}/rules/{id}`. Since PUT is a full replacement, the API returned 422 Unprocessable Entity when required fields (`name`, `match`, `conditions`, `actions`) were missing from the body.

## Fix

- Fetch the existing rule with a GET before updating
- Merge the caller's changes on top of the existing rule
- PUT the complete merged object

This preserves all existing rule fields while still allowing partial updates as the tool description advertises.