### PR TITLE
000: enable groups API v2 tools

### DIFF
--- a/lib/tools/groups.js
+++ b/lib/tools/groups.js
@@ -1,14 +1,11 @@
 /**
  * OneLogin Groups Tools
- * API Reference: /api/1/groups (API v1 - read-only)
- *
- * TODO: Switch back to /api/2/groups and re-enable create, update, delete,
- * and get_group_users once the api/2 groups endpoints are deployed.
+ * API Reference: /api/2/groups
  */
 
 /**
  * List OneLogin groups
- * Reference: GET /api/1/groups
+ * Reference: GET /api/2/groups
  * Supports wildcard search with * (e.g., name=Engineering*)
  * @param {OneLoginApi} api
  * @param {Object} args - Filters and pagination
@@ -28,12 +25,12 @@ export async function listGroups(api, args = {}) {
   if (args.after_cursor) params.after_cursor = args.after_cursor;
   if (args.before_cursor) params.before_cursor = args.before_cursor;
 
-  return await api.get('/api/1/groups', params);
+  return await api.get('/api/2/groups', params);
 }
 
 /**
  * Get a specific group by ID
- * Reference: GET /api/1/groups/{id}
+ * Reference: GET /api/2/groups/{id}
  * @param {OneLoginApi} api
  * @param {Object} args - {group_id: number}
  * @returns {Promise<Object>}
@@ -43,81 +40,78 @@ export async function getGroup(api, args) {
     throw new Error('group_id is required');
   }
 
-  return await api.get(`/api/1/groups/${args.group_id}`);
+  return await api.get(`/api/2/groups/${args.group_id}`);
 }
 
-// TODO: Re-enable these functions when /api/2/groups is deployed.
-// They require api/2 which supports full CRUD and richer responses.
+/**
+ * Create a new group
+ * POST /api/2/groups
+ * @param {OneLoginApi} api
+ * @param {Object} args - Group data (name, reference, policy_id)
+ * @returns {Promise<Object>}
+ */
+export async function createGroup(api, args) {
+  if (!args.name) {
+    throw new Error('name is required');
+  }
 
-// /**
-//  * Create a new group
-//  * POST /api/2/groups
-//  * @param {OneLoginApi} api
-//  * @param {Object} args - Group data (name, reference, policy_id)
-//  * @returns {Promise<Object>}
-//  */
-// export async function createGroup(api, args) {
-//   if (!args.name) {
-//     throw new Error('name is required');
-//   }
-//
-//   return await api.post('/api/2/groups', args);
-// }
+  return await api.post('/api/2/groups', args);
+}
 
-// /**
-//  * Update an existing group
-//  * PUT /api/2/groups/{group_id}
-//  * @param {OneLoginApi} api
-//  * @param {Object} args - {group_id: number, ...fields to update}
-//  * @returns {Promise<Object>}
-//  */
-// export async function updateGroup(api, args) {
-//   if (!args.group_id) {
-//     throw new Error('group_id is required');
-//   }
-//
-//   const groupId = args.group_id;
-//   const updateData = { ...args };
-//   delete updateData.group_id;
-//
-//   return await api.put(`/api/2/groups/${groupId}`, updateData);
-// }
+/**
+ * Update an existing group
+ * PUT /api/2/groups/{group_id}
+ * @param {OneLoginApi} api
+ * @param {Object} args - {group_id: number, ...fields to update}
+ * @returns {Promise<Object>}
+ */
+export async function updateGroup(api, args) {
+  if (!args.group_id) {
+    throw new Error('group_id is required');
+  }
 
-// /**
-//  * Delete a group
-//  * DELETE /api/2/groups/{group_id}
-//  * @param {OneLoginApi} api
-//  * @param {Object} args - {group_id: number}
-//  * @returns {Promise<Object>}
-//  */
-// export async function deleteGroup(api, args) {
-//   if (!args.group_id) {
-//     throw new Error('group_id is required');
-//   }
-//
-//   return await api.delete(`/api/2/groups/${args.group_id}`);
-// }
+  const groupId = args.group_id;
+  const updateData = { ...args };
+  delete updateData.group_id;
 
-// /**
-//  * Get users assigned to a group
-//  * GET /api/2/groups/{group_id} (extracts users array from response)
-//  * @param {OneLoginApi} api
-//  * @param {Object} args - {group_id: number}
-//  * @returns {Promise<Object>}
-//  */
-// export async function getGroupUsers(api, args) {
-//   if (!args.group_id) {
-//     throw new Error('group_id is required');
-//   }
-//
-//   const response = await api.get(`/api/2/groups/${args.group_id}`);
-//
-//   // Extract users array from the group response
-//   return {
-//     ...response,
-//     data: response.data?.users || []
-//   };
-// }
+  return await api.put(`/api/2/groups/${groupId}`, updateData);
+}
+
+/**
+ * Delete a group
+ * DELETE /api/2/groups/{group_id}
+ * @param {OneLoginApi} api
+ * @param {Object} args - {group_id: number}
+ * @returns {Promise<Object>}
+ */
+export async function deleteGroup(api, args) {
+  if (!args.group_id) {
+    throw new Error('group_id is required');
+  }
+
+  return await api.delete(`/api/2/groups/${args.group_id}`);
+}
+
+/**
+ * Get users assigned to a group
+ * GET /api/2/groups/{group_id} (extracts users array from response)
+ * @param {OneLoginApi} api
+ * @param {Object} args - {group_id: number}
+ * @returns {Promise<Object>}
+ */
+export async function getGroupUsers(api, args) {
+  if (!args.group_id) {
+    throw new Error('group_id is required');
+  }
+
+  const response = await api.get(`/api/2/groups/${args.group_id}`);
+
+  // Extract users array from the group response
+  return {
+    ...response,
+    data: response.data?.users || []
+  };
+}
 
 /**
  * Tool Definitions for MCP
@@ -150,63 +144,60 @@ export const tools = [
       required: ['group_id'],
       additionalProperties: false
     }
+  },
+  {
+    name: 'create_group',
+    description: 'Create a new group with optional policy assignment. Groups are used to organize users and can have policies assigned for access control. Returns created group data with new group ID and x-request-id for log tracing.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Group name (required, must be unique within account)' },
+        reference: { type: 'string', description: 'External reference ID (optional, must be unique if provided)' },
+        policy_id: { type: 'number', description: 'Policy ID to assign to the group (optional)' }
+      },
+      required: ['name'],
+      additionalProperties: false
+    }
+  },
+  {
+    name: 'update_group',
+    description: 'Update an existing group. Partial updates are supported - only provide the fields you want to change (name, reference, policy_id). Name and reference must remain unique within the account. Returns updated group data and x-request-id for log tracing.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        group_id: { type: 'number', description: 'The OneLogin group ID to update' },
+        name: { type: 'string', description: 'New group name (must be unique)' },
+        reference: { type: 'string', description: 'New external reference ID (must be unique if provided)' },
+        policy_id: { type: 'number', description: 'Policy ID to assign to the group' }
+      },
+      required: ['group_id'],
+      additionalProperties: false
+    }
+  },
+  {
+    name: 'delete_group',
+    description: 'Delete a group from OneLogin. WARNING: This operation is final and cannot be undone. Users in the group will not be deleted, only the group membership is removed. The group itself is permanently deleted. Returns 204 No Content on success and x-request-id for log tracing.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        group_id: { type: 'number', description: 'The OneLogin group ID to delete' }
+      },
+      required: ['group_id'],
+      additionalProperties: false
+    }
+  },
+  {
+    name: 'get_group_users',
+    description: 'Get users assigned to a group. Returns a list of users who are members of the specified group with details including ID, email, firstname, lastname. Use this to see group membership. Returns x-request-id for log tracing.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        group_id: { type: 'number', description: 'The OneLogin group ID' }
+      },
+      required: ['group_id'],
+      additionalProperties: false
+    }
   }
-
-  // TODO: Re-enable these tool definitions when /api/2/groups is deployed:
-  //
-  // {
-  //   name: 'create_group',
-  //   description: 'Create a new group with optional policy assignment. Groups are used to organize users and can have policies assigned for access control. Returns created group data with new group ID and x-request-id for log tracing.',
-  //   inputSchema: {
-  //     type: 'object',
-  //     properties: {
-  //       name: { type: 'string', description: 'Group name (required, must be unique within account)' },
-  //       reference: { type: 'string', description: 'External reference ID (optional, must be unique if provided)' },
-  //       policy_id: { type: 'number', description: 'Policy ID to assign to the group (optional)' }
-  //     },
-  //     required: ['name'],
-  //     additionalProperties: false
-  //   }
-  // },
-  // {
-  //   name: 'update_group',
-  //   description: 'Update an existing group. Partial updates are supported - only provide the fields you want to change (name, reference, policy_id). Name and reference must remain unique within the account. Returns updated group data and x-request-id for log tracing.',
-  //   inputSchema: {
-  //     type: 'object',
-  //     properties: {
-  //       group_id: { type: 'number', description: 'The OneLogin group ID to update' },
-  //       name: { type: 'string', description: 'New group name (must be unique)' },
-  //       reference: { type: 'string', description: 'New external reference ID (must be unique if provided)' },
-  //       policy_id: { type: 'number', description: 'Policy ID to assign to the group' }
-  //     },
-  //     required: ['group_id'],
-  //     additionalProperties: false
-  //   }
-  // },
-  // {
-  //   name: 'delete_group',
-  //   description: 'Delete a group from OneLogin. WARNING: This operation is final and cannot be undone. Users in the group will not be deleted, only the group membership is removed. The group itself is permanently deleted. Returns 204 No Content on success and x-request-id for log tracing.',
-  //   inputSchema: {
-  //     type: 'object',
-  //     properties: {
-  //       group_id: { type: 'number', description: 'The OneLogin group ID to delete' }
-  //     },
-  //     required: ['group_id'],
-  //     additionalProperties: false
-  //   }
-  // },
-  // {
-  //   name: 'get_group_users',
-  //   description: 'Get users assigned to a group. Returns a list of users who are members of the specified group with details including ID, email, firstname, lastname. Use this to see group membership. Returns x-request-id for log tracing.',
-  //   inputSchema: {
-  //     type: 'object',
-  //     properties: {
-  //       group_id: { type: 'number', description: 'The OneLogin group ID' }
-  //     },
-  //     required: ['group_id'],
-  //     additionalProperties: false
-  //   }
-  // }
 ];
 
 /**
@@ -214,10 +205,9 @@ export const tools = [
  */
 export const handlers = {
   list_groups: listGroups,
-  get_group: getGroup
-  // TODO: Re-enable when /api/2/groups is deployed:
-  // create_group: createGroup,
-  // update_group: updateGroup,
-  // delete_group: deleteGroup,
-  // get_group_users: getGroupUsers
+  get_group: getGroup,
+  create_group: createGroup,
+  update_group: updateGroup,
+  delete_group: deleteGroup,
+  get_group_users: getGroupUsers
 };


### PR DESCRIPTION
- Upgrade `list_groups` and `get_group` from `/api/1/groups` to `/api/2/groups`
- Enable previously-disabled tools: `create_group`, `update_group`, `delete_group`, `get_group_users` now that `/api/2/groups` is deployed in core-api

Fixes #41