### PR TITLE
fix: api-authorization create/update payload shape

### DIFF
--- a/lib/tools/api-authorization.js
+++ b/lib/tools/api-authorization.js
@@ -42,14 +42,22 @@ export async function getApiAuthorization(api, args) {
 /**
  * Build an API authorization request body from user args.
  *
- * Accepted top-level fields: `name`, `description`, `connector_id`,
- * `scopes`, `claims`, and a nested `configuration` object. Allowed
- * configuration keys are `audiences`, `resource_identifier`,
- * `access_token_expiration_minutes`, and `refresh_token_expiration_minutes`.
- * Unknown configuration keys are silently ignored by the core-api adapter
- * (`translate_configuration_hash`), but the tool schemas enforce
- * `additionalProperties: false` on both create and update so callers get
- * a clear error up front instead of wondering why their field was dropped.
+ * Top-level fields copied through verbatim when present: `name`,
+ * `description`, `connector_id`, `scopes`, `claims`. Of these, only
+ * `name`/`description`/`configuration` are meaningful on update —
+ * `connector_id` is `attr_readonly` on the model, and scopes/claims are
+ * "only accepted while creating the App" per the core-api adapter, so
+ * the update tool schema doesn't expose them. This helper is shared
+ * because the shape of the body that *is* allowed on update is identical
+ * to the corresponding subset on create.
+ *
+ * The nested `configuration` object accepts `audiences`,
+ * `resource_identifier`, `access_token_expiration_minutes`, and
+ * `refresh_token_expiration_minutes`. Unknown configuration keys are
+ * silently ignored by the core-api adapter (`translate_configuration_hash`),
+ * but both tool schemas enforce `additionalProperties: false` so callers
+ * get a clear error up front instead of wondering why their field was
+ * dropped.
  *
  * As a convenience, top-level `audience`/`audiences`/`resource_identifier`
  * and the `*_expiration_minutes` fields are hoisted into `configuration`.
@@ -469,13 +477,13 @@ export const tools = [
   },
   {
     name: 'create_api_authorization',
-    description: 'Create a new API authorization (OAuth 2.0 resource server) to protect your APIs with OneLogin. Required: name. Optional: description, connector_id (defaults to the generic OneLogin API connector), and a nested configuration object ({audiences, resource_identifier, access_token_expiration_minutes, refresh_token_expiration_minutes}). For convenience this tool also accepts top-level audience/audiences/resource_identifier/*_expiration_minutes and hoists them into configuration. Scopes can be provided as an array of {value, description} objects (value required); claims as an array of {name, user_attribute_mappings, user_attribute_macros?, attributes_transformations?} objects (name and user_attribute_mappings required) — both created alongside the authorization. Returns created authorization with ID and x-request-id.',
+    description: 'Create a new API authorization (OAuth 2.0 resource server) to protect your APIs with OneLogin. Required: name. Optional: description, connector_id (omit to use the account default API authorization connector), and a nested configuration object ({audiences, resource_identifier, access_token_expiration_minutes, refresh_token_expiration_minutes}). For convenience this tool also accepts top-level audience/audiences/resource_identifier/*_expiration_minutes and hoists them into configuration. Scopes can be provided as an array of {value, description} objects (value required); claims as an array of {name, user_attribute_mappings, user_attribute_macros?, attributes_transformations?} objects (name and user_attribute_mappings required) — both created alongside the authorization. Returns created authorization with ID and x-request-id.',
     inputSchema: {
       type: 'object',
       properties: {
         name: { type: 'string', description: 'Authorization name' },
         description: { type: 'string', description: 'Authorization description' },
-        connector_id: { type: 'number', description: 'Connector ID; omit to use the account default' },
+        connector_id: { type: 'number', description: 'Connector ID; omit to use the account default API authorization connector' },
         audience: { type: 'string', description: 'Convenience alias for configuration.audiences' },
         audiences: { type: 'string', description: 'Convenience alias for configuration.audiences' },
         resource_identifier: { type: 'string', description: 'Convenience alias for configuration.resource_identifier' },
@@ -527,7 +535,7 @@ export const tools = [
   },
   {
     name: 'update_api_authorization',
-    description: 'Update an existing API authorization configuration. The OneLogin API requires BOTH auth_id and name on update (it is not a true partial update). Can modify description and nested configuration (audiences, resource_identifier, token expirations). Top-level audience/audiences/resource_identifier/*_expiration_minutes are hoisted into configuration. IMPORTANT: Changing audiences will break existing access tokens. Returns updated authorization data and x-request-id.',
+    description: 'Update an existing API authorization configuration. The OneLogin API requires BOTH auth_id and name on update (it is not a true partial update). Can modify description and nested configuration (audiences, resource_identifier, token expirations). Top-level audience/audiences/resource_identifier/*_expiration_minutes are hoisted into configuration. NOTE: connector_id, scopes, and claims cannot be changed here — connector_id is read-only on the model, and scopes/claims are only accepted on create; use add_authorization_scopes / add_authorization_claim etc. to manage them afterwards. IMPORTANT: Changing audiences will break existing access tokens. Returns updated authorization data and x-request-id.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/lib/tools/api-authorization.js
+++ b/lib/tools/api-authorization.js
@@ -40,6 +40,47 @@ export async function getApiAuthorization(api, args) {
 }
 
 /**
+ * Build an API authorization request body from user args.
+ * The OneLogin API only accepts `name`, `description`, `connector_id`,
+ * `scopes`, `claims`, and a nested `configuration` object containing
+ * `audiences`, `resource_identifier`, `access_token_expiration_minutes`,
+ * and `refresh_token_expiration_minutes`. Top-level `audience(s)` or
+ * token-expiration fields are hoisted into `configuration` for
+ * convenience; unknown top-level fields would otherwise cause the API
+ * to reject the request.
+ */
+function buildAuthorizationBody(args) {
+  const body = {};
+  const topLevelFields = ['name', 'description', 'connector_id', 'scopes', 'claims'];
+  for (const field of topLevelFields) {
+    if (args[field] !== undefined) body[field] = args[field];
+  }
+
+  const configuration = { ...(args.configuration || {}) };
+  if (args.audience !== undefined && configuration.audiences === undefined) {
+    configuration.audiences = args.audience;
+  }
+  if (args.audiences !== undefined && configuration.audiences === undefined) {
+    configuration.audiences = args.audiences;
+  }
+  if (args.resource_identifier !== undefined && configuration.resource_identifier === undefined) {
+    configuration.resource_identifier = args.resource_identifier;
+  }
+  if (args.access_token_expiration_minutes !== undefined && configuration.access_token_expiration_minutes === undefined) {
+    configuration.access_token_expiration_minutes = args.access_token_expiration_minutes;
+  }
+  if (args.refresh_token_expiration_minutes !== undefined && configuration.refresh_token_expiration_minutes === undefined) {
+    configuration.refresh_token_expiration_minutes = args.refresh_token_expiration_minutes;
+  }
+
+  if (Object.keys(configuration).length > 0) {
+    body.configuration = configuration;
+  }
+
+  return body;
+}
+
+/**
  * Create a new API authorization
  * POST /api/2/api_authorizations
  * @param {OneLoginApi} api
@@ -51,26 +92,27 @@ export async function createApiAuthorization(api, args) {
     throw new Error('name is required');
   }
 
-  return await api.post('/api/2/api_authorizations', args);
+  return await api.post('/api/2/api_authorizations', buildAuthorizationBody(args));
 }
 
 /**
  * Update an API authorization
  * PUT /api/2/api_authorizations/{id}
  * @param {OneLoginApi} api
- * @param {Object} args - {auth_id: number, ...fields to update}
+ * @param {Object} args - {auth_id: number, name: string, ...fields to update}
  * @returns {Promise<Object>}
  */
 export async function updateApiAuthorization(api, args) {
   if (!args.auth_id) {
     throw new Error('auth_id is required');
   }
+  // core-api enforces required_params :name on both create and update
+  if (!args.name) {
+    throw new Error('name is required (the OneLogin API requires name on update, not just on create)');
+  }
 
-  const authId = args.auth_id;
-  const updateData = { ...args };
-  delete updateData.auth_id;
-
-  return await api.put(`/api/2/api_authorizations/${authId}`, updateData);
+  const { auth_id: authId, ...rest } = args;
+  return await api.put(`/api/2/api_authorizations/${authId}`, buildAuthorizationBody(rest));
 }
 
 /**
@@ -411,31 +453,72 @@ export const tools = [
   },
   {
     name: 'create_api_authorization',
-    description: 'Create a new API authorization (OAuth 2.0 resource server) to protect your APIs with OneLogin. Required: name (descriptive label). Recommended: audience (unique identifier, defaults to name), description. Access tokens issued for this authorization will include the audience claim. Define scopes with add_authorization_scopes after creation. Returns created authorization with ID and x-request-id.',
+    description: 'Create a new API authorization (OAuth 2.0 resource server) to protect your APIs with OneLogin. Required: name. Optional: description, connector_id (defaults to the generic OneLogin API connector), and a nested configuration object ({audiences, resource_identifier, access_token_expiration_minutes, refresh_token_expiration_minutes}). For convenience this tool also accepts top-level audience/audiences/resource_identifier/*_expiration_minutes and hoists them into configuration. Scopes and claims can be provided as arrays of {value, description} objects to create alongside the authorization. Returns created authorization with ID and x-request-id.',
     inputSchema: {
       type: 'object',
       properties: {
         name: { type: 'string', description: 'Authorization name' },
         description: { type: 'string', description: 'Authorization description' },
-        audience: { type: 'string', description: 'Unique audience identifier (defaults to name)' }
+        connector_id: { type: 'number', description: 'Connector ID; omit to use the account default' },
+        audience: { type: 'string', description: 'Convenience alias for configuration.audiences' },
+        audiences: { type: 'string', description: 'Convenience alias for configuration.audiences' },
+        resource_identifier: { type: 'string', description: 'Convenience alias for configuration.resource_identifier' },
+        access_token_expiration_minutes: { type: 'number', description: 'Convenience alias for configuration.access_token_expiration_minutes' },
+        refresh_token_expiration_minutes: { type: 'number', description: 'Convenience alias for configuration.refresh_token_expiration_minutes' },
+        configuration: {
+          type: 'object',
+          description: 'Nested configuration (takes precedence over convenience aliases above)',
+          properties: {
+            audiences: { type: 'string' },
+            resource_identifier: { type: 'string' },
+            access_token_expiration_minutes: { type: 'number' },
+            refresh_token_expiration_minutes: { type: 'number' }
+          },
+          additionalProperties: true
+        },
+        scopes: {
+          type: 'array',
+          description: 'Optional scopes to create with the authorization, as {value, description} objects',
+          items: { type: 'object' }
+        },
+        claims: {
+          type: 'array',
+          description: 'Optional claims to create with the authorization',
+          items: { type: 'object' }
+        }
       },
       required: ['name'],
-      additionalProperties: true
+      additionalProperties: false
     }
   },
   {
     name: 'update_api_authorization',
-    description: 'Update an existing API authorization configuration. Can modify name, description, audience, and token settings. Partial updates supported - only provide fields to change. IMPORTANT: Changing audience will break existing access tokens. Returns updated authorization data and x-request-id.',
+    description: 'Update an existing API authorization configuration. The OneLogin API requires BOTH auth_id and name on update (it is not a true partial update). Can modify description and nested configuration (audiences, resource_identifier, token expirations). Top-level audience/audiences/resource_identifier/*_expiration_minutes are hoisted into configuration. IMPORTANT: Changing audiences will break existing access tokens. Returns updated authorization data and x-request-id.',
     inputSchema: {
       type: 'object',
       properties: {
         auth_id: { type: 'number', description: 'The API authorization ID to update' },
-        name: { type: 'string', description: 'New name' },
+        name: { type: 'string', description: 'Name (required by the API even on update)' },
         description: { type: 'string', description: 'New description' },
-        audience: { type: 'string', description: 'New audience identifier' }
+        audience: { type: 'string', description: 'Convenience alias for configuration.audiences' },
+        audiences: { type: 'string', description: 'Convenience alias for configuration.audiences' },
+        resource_identifier: { type: 'string', description: 'Convenience alias for configuration.resource_identifier' },
+        access_token_expiration_minutes: { type: 'number', description: 'Convenience alias for configuration.access_token_expiration_minutes' },
+        refresh_token_expiration_minutes: { type: 'number', description: 'Convenience alias for configuration.refresh_token_expiration_minutes' },
+        configuration: {
+          type: 'object',
+          description: 'Nested configuration (takes precedence over convenience aliases above)',
+          properties: {
+            audiences: { type: 'string' },
+            resource_identifier: { type: 'string' },
+            access_token_expiration_minutes: { type: 'number' },
+            refresh_token_expiration_minutes: { type: 'number' }
+          },
+          additionalProperties: true
+        }
       },
-      required: ['auth_id'],
-      additionalProperties: true
+      required: ['auth_id', 'name'],
+      additionalProperties: false
     }
   },
   {

--- a/lib/tools/api-authorization.js
+++ b/lib/tools/api-authorization.js
@@ -43,12 +43,13 @@ export async function getApiAuthorization(api, args) {
  * Build an API authorization request body from user args.
  *
  * Accepted top-level fields: `name`, `description`, `connector_id`,
- * `scopes`, `claims`, and a nested `configuration` object. Known
+ * `scopes`, `claims`, and a nested `configuration` object. Allowed
  * configuration keys are `audiences`, `resource_identifier`,
- * `access_token_expiration_minutes`, and `refresh_token_expiration_minutes`;
- * any other configuration keys are accepted but silently ignored by the
- * core-api adapter (see `translate_configuration_hash`), so we pass them
- * through unchanged.
+ * `access_token_expiration_minutes`, and `refresh_token_expiration_minutes`.
+ * Unknown configuration keys are silently ignored by the core-api adapter
+ * (`translate_configuration_hash`), but the tool schemas enforce
+ * `additionalProperties: false` on both create and update so callers get
+ * a clear error up front instead of wondering why their field was dropped.
  *
  * As a convenience, top-level `audience`/`audiences`/`resource_identifier`
  * and the `*_expiration_minutes` fields are hoisted into `configuration`.
@@ -468,7 +469,7 @@ export const tools = [
   },
   {
     name: 'create_api_authorization',
-    description: 'Create a new API authorization (OAuth 2.0 resource server) to protect your APIs with OneLogin. Required: name. Optional: description, connector_id (defaults to the generic OneLogin API connector), and a nested configuration object ({audiences, resource_identifier, access_token_expiration_minutes, refresh_token_expiration_minutes}). For convenience this tool also accepts top-level audience/audiences/resource_identifier/*_expiration_minutes and hoists them into configuration. Scopes and claims can be provided as arrays of {value, description} objects to create alongside the authorization. Returns created authorization with ID and x-request-id.',
+    description: 'Create a new API authorization (OAuth 2.0 resource server) to protect your APIs with OneLogin. Required: name. Optional: description, connector_id (defaults to the generic OneLogin API connector), and a nested configuration object ({audiences, resource_identifier, access_token_expiration_minutes, refresh_token_expiration_minutes}). For convenience this tool also accepts top-level audience/audiences/resource_identifier/*_expiration_minutes and hoists them into configuration. Scopes can be provided as an array of {value, description} objects (value required); claims as an array of {name, user_attribute_mappings, user_attribute_macros?, attributes_transformations?} objects (name and user_attribute_mappings required) — both created alongside the authorization. Returns created authorization with ID and x-request-id.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -547,7 +548,7 @@ export const tools = [
             access_token_expiration_minutes: { type: 'number' },
             refresh_token_expiration_minutes: { type: 'number' }
           },
-          additionalProperties: true
+          additionalProperties: false
         }
       },
       required: ['auth_id', 'name'],

--- a/lib/tools/api-authorization.js
+++ b/lib/tools/api-authorization.js
@@ -41,14 +41,28 @@ export async function getApiAuthorization(api, args) {
 
 /**
  * Build an API authorization request body from user args.
- * The OneLogin API only accepts `name`, `description`, `connector_id`,
- * `scopes`, `claims`, and a nested `configuration` object containing
- * `audiences`, `resource_identifier`, `access_token_expiration_minutes`,
- * and `refresh_token_expiration_minutes`. Top-level `audience(s)` or
- * token-expiration fields are hoisted into `configuration` for
- * convenience; unknown top-level fields would otherwise cause the API
- * to reject the request.
+ *
+ * Accepted top-level fields: `name`, `description`, `connector_id`,
+ * `scopes`, `claims`, and a nested `configuration` object. Known
+ * configuration keys are `audiences`, `resource_identifier`,
+ * `access_token_expiration_minutes`, and `refresh_token_expiration_minutes`;
+ * any other configuration keys are accepted but silently ignored by the
+ * core-api adapter (see `translate_configuration_hash`), so we pass them
+ * through unchanged.
+ *
+ * As a convenience, top-level `audience`/`audiences`/`resource_identifier`
+ * and the `*_expiration_minutes` fields are hoisted into `configuration`.
+ * Precedence is: explicit `configuration.<key>` > top-level `audiences` >
+ * top-level `audience`. If `audience` and `audiences` are both provided at
+ * the top level with different values, we throw rather than silently
+ * picking one.
  */
+function hoist(configuration, key, value) {
+  if (value !== undefined && configuration[key] === undefined) {
+    configuration[key] = value;
+  }
+}
+
 function buildAuthorizationBody(args) {
   const body = {};
   const topLevelFields = ['name', 'description', 'connector_id', 'scopes', 'claims'];
@@ -57,21 +71,22 @@ function buildAuthorizationBody(args) {
   }
 
   const configuration = { ...(args.configuration || {}) };
-  if (args.audience !== undefined && configuration.audiences === undefined) {
-    configuration.audiences = args.audience;
+
+  if (
+    args.audience !== undefined &&
+    args.audiences !== undefined &&
+    args.audience !== args.audiences
+  ) {
+    throw new Error(
+      'Provide either `audience` or `audiences` (or configuration.audiences), not both with different values'
+    );
   }
-  if (args.audiences !== undefined && configuration.audiences === undefined) {
-    configuration.audiences = args.audiences;
-  }
-  if (args.resource_identifier !== undefined && configuration.resource_identifier === undefined) {
-    configuration.resource_identifier = args.resource_identifier;
-  }
-  if (args.access_token_expiration_minutes !== undefined && configuration.access_token_expiration_minutes === undefined) {
-    configuration.access_token_expiration_minutes = args.access_token_expiration_minutes;
-  }
-  if (args.refresh_token_expiration_minutes !== undefined && configuration.refresh_token_expiration_minutes === undefined) {
-    configuration.refresh_token_expiration_minutes = args.refresh_token_expiration_minutes;
-  }
+  // audiences > audience (audiences is the canonical API key)
+  hoist(configuration, 'audiences', args.audiences);
+  hoist(configuration, 'audiences', args.audience);
+  hoist(configuration, 'resource_identifier', args.resource_identifier);
+  hoist(configuration, 'access_token_expiration_minutes', args.access_token_expiration_minutes);
+  hoist(configuration, 'refresh_token_expiration_minutes', args.refresh_token_expiration_minutes);
 
   if (Object.keys(configuration).length > 0) {
     body.configuration = configuration;
@@ -474,17 +489,35 @@ export const tools = [
             access_token_expiration_minutes: { type: 'number' },
             refresh_token_expiration_minutes: { type: 'number' }
           },
-          additionalProperties: true
+          additionalProperties: false
         },
         scopes: {
           type: 'array',
-          description: 'Optional scopes to create with the authorization, as {value, description} objects',
-          items: { type: 'object' }
+          description: 'Optional scopes to create alongside the authorization',
+          items: {
+            type: 'object',
+            properties: {
+              value: { type: 'string', description: 'Scope identifier (e.g., "contact:read")' },
+              description: { type: 'string', description: 'Human-readable description' }
+            },
+            required: ['value'],
+            additionalProperties: false
+          }
         },
         claims: {
           type: 'array',
-          description: 'Optional claims to create with the authorization',
-          items: { type: 'object' }
+          description: 'Optional claims to create alongside the authorization',
+          items: {
+            type: 'object',
+            properties: {
+              name: { type: 'string', description: 'Claim name as it appears in the JWT token' },
+              user_attribute_mappings: { type: 'string', description: 'OneLogin user attribute to map' },
+              user_attribute_macros: { type: 'string', description: 'Macro logic when user_attribute_mappings is "_macro_"' },
+              attributes_transformations: { type: 'string', description: 'Transformation to apply' }
+            },
+            required: ['name', 'user_attribute_mappings'],
+            additionalProperties: false
+          }
         }
       },
       required: ['name'],


### PR DESCRIPTION
## Summary

Fixes #45 — `create_api_authorization` and `update_api_authorization` MCP tools both failed against the OneLogin API.

## Root cause

- The `ApiAuthorizationApp` model only `attr_accessible`s `name`, `description`, and `api_authorization_config_values_attributes`. The MCP was sending `audience` at the top level, but the adapter expects it nested under `configuration.audiences` (plural). Unknown top-level fields are rejected.
- `Api::V5::ApiAuthAppsController` declares `required_params :name, :only => [:create, :update]` — so update is **not** a partial update. The MCP schema marked only `auth_id` required, so the model frequently omitted `name` and got a 400.
- Delete has no body and no required-params check, which is why the reporter confirmed delete still worked.

## Changes

- New `buildAuthorizationBody()` helper hoists top-level `audience` / `audiences` / `resource_identifier` / `access_token_expiration_minutes` / `refresh_token_expiration_minutes` into a nested `configuration` object. Throws if conflicting top-level `audience`/`audiences` values are provided; precedence is `configuration.audiences` > `audiences` > `audience`.
- `updateApiAuthorization` now requires `name` (matches the server) and throws a descriptive error if missing.
- `create_api_authorization` schema exposes `connector_id`, nested `configuration`, and typed `scopes` (`{value, description?}`, value required) and `claims` (`{name, user_attribute_mappings, user_attribute_macros?, attributes_transformations?}`, name + user_attribute_mappings required) arrays. `additionalProperties: false` at every level.
- `update_api_authorization` schema requires `name` in addition to `auth_id`, and intentionally does **not** expose `connector_id`/`scopes`/`claims` — `connector_id` is `attr_readonly` on the model, and scopes/claims are create-only per the core-api adapter. Use `add_authorization_scopes` / `add_authorization_claim` etc. to manage them afterwards.

## Test plan

- [ ] `create_api_authorization` with `{name, description}` succeeds (uses account default connector)
- [ ] `create_api_authorization` with `{name, audience: "foo"}` succeeds — audience is nested into configuration
- [ ] `create_api_authorization` with `{name, configuration: {audiences: "foo"}}` succeeds
- [ ] `create_api_authorization` with both `audience: "a"` and `audiences: "b"` fails with a clear error
- [ ] `update_api_authorization` with `{auth_id, name, description}` succeeds
- [ ] `update_api_authorization` without `name` returns a clear error before hitting the API
- [ ] `delete_api_authorization` still works (regression check)