### PR TITLE
Fix add/remove_authorized_clients to use REST resource shape

### DIFF
--- a/lib/tools/api-authorization.js
+++ b/lib/tools/api-authorization.js
@@ -229,43 +229,80 @@ export async function listAuthorizedClients(api, args) {
 /**
  * Authorize clients for an API authorization
  * POST /api/2/api_authorizations/{id}/clients
+ *
+ * core-api routes /clients as a standard REST resource: each call creates ONE
+ * client association from {app_id, scopes}. scopes is required (it's an array
+ * of numeric API scope IDs owned by this authorization — list them via
+ * list_authorization_scopes). To attach multiple clients in a single tool call
+ * we accept an array and iterate; partial failures surface as per-item errors.
+ *
  * @param {OneLoginApi} api
- * @param {Object} args - {auth_id: number, client_ids: number[]}
- * @returns {Promise<Object>}
+ * @param {Object} args - {auth_id: number, clients: Array<{app_id: number, scopes: number[]}>}
+ * @returns {Promise<{results: Array<{app_id: number, status: 'ok'|'error', data?: Object, error?: string}>}>}
  */
 export async function addAuthorizedClients(api, args) {
   if (!args.auth_id) {
     throw new Error('auth_id is required');
   }
 
-  if (!args.client_ids || !Array.isArray(args.client_ids)) {
-    throw new Error('client_ids array is required');
+  if (!args.clients || !Array.isArray(args.clients) || args.clients.length === 0) {
+    throw new Error('clients array is required (each item: {app_id, scopes: number[]})');
   }
 
-  return await api.post(`/api/2/api_authorizations/${args.auth_id}/clients`, {
-    client_ids: args.client_ids
-  });
+  const results = [];
+  for (const client of args.clients) {
+    if (!client.app_id) {
+      results.push({ app_id: null, status: 'error', error: 'app_id is required on each client' });
+      continue;
+    }
+    if (!Array.isArray(client.scopes)) {
+      results.push({ app_id: client.app_id, status: 'error', error: 'scopes array is required on each client' });
+      continue;
+    }
+    try {
+      const data = await api.post(
+        `/api/2/api_authorizations/${args.auth_id}/clients`,
+        { app_id: client.app_id, scopes: client.scopes }
+      );
+      results.push({ app_id: client.app_id, status: 'ok', data });
+    } catch (err) {
+      results.push({ app_id: client.app_id, status: 'error', error: err.message });
+    }
+  }
+  return { results };
 }
 
 /**
  * Remove authorized clients from an API authorization
- * DELETE /api/2/api_authorizations/{id}/clients
+ * DELETE /api/2/api_authorizations/{id}/clients/{app_id}
+ *
+ * The route is keyed by the OIDC app's `app_id` (matching what
+ * list_authorized_clients returns), not a separate client_id. One DELETE per
+ * app; we iterate and report per-item status.
+ *
  * @param {OneLoginApi} api
- * @param {Object} args - {auth_id: number, client_ids: number[]}
- * @returns {Promise<Object>}
+ * @param {Object} args - {auth_id: number, app_ids: number[]}
+ * @returns {Promise<{results: Array<{app_id: number, status: 'ok'|'error', error?: string}>}>}
  */
 export async function removeAuthorizedClients(api, args) {
   if (!args.auth_id) {
     throw new Error('auth_id is required');
   }
 
-  if (!args.client_ids || !Array.isArray(args.client_ids)) {
-    throw new Error('client_ids array is required');
+  if (!args.app_ids || !Array.isArray(args.app_ids) || args.app_ids.length === 0) {
+    throw new Error('app_ids array is required (OIDC app IDs as returned by list_authorized_clients)');
   }
 
-  return await api.delete(`/api/2/api_authorizations/${args.auth_id}/clients`, {
-    client_ids: args.client_ids
-  });
+  const results = [];
+  for (const appId of args.app_ids) {
+    try {
+      await api.delete(`/api/2/api_authorizations/${args.auth_id}/clients/${appId}`);
+      results.push({ app_id: appId, status: 'ok' });
+    } catch (err) {
+      results.push({ app_id: appId, status: 'error', error: err.message });
+    }
+  }
+  return { results };
 }
 
 /**
@@ -635,35 +672,49 @@ export const tools = [
   },
   {
     name: 'add_authorized_clients',
-    description: 'Grant client apps permission to request access tokens for this API authorization. Provide array of client app IDs. Clients can then use OAuth client credentials flow to get tokens with this authorization\'s audience and allowed scopes. Returns success status and x-request-id.',
+    description: 'Grant OIDC client apps permission to request access tokens for this API authorization. Each client needs an app_id (the OIDC app ID from list_apps or as returned by list_authorized_clients) and a scopes array of numeric API scope IDs (get these from list_authorization_scopes — scope value strings will NOT work here). The underlying API creates one client association per call; pass multiple {app_id, scopes} objects to register several in one shot. Returns a results array with per-client ok/error status.',
     inputSchema: {
       type: 'object',
       properties: {
         auth_id: { type: 'number', description: 'The API authorization ID' },
-        client_ids: {
+        clients: {
           type: 'array',
-          items: { type: 'number' },
-          description: 'Array of client app IDs to authorize'
+          description: 'Array of client associations to create',
+          items: {
+            type: 'object',
+            properties: {
+              app_id: { type: 'number', description: 'OIDC app ID to authorize' },
+              scopes: {
+                type: 'array',
+                items: { type: 'number' },
+                description: 'Numeric API scope IDs to grant (from list_authorization_scopes)'
+              }
+            },
+            required: ['app_id', 'scopes'],
+            additionalProperties: false
+          },
+          minItems: 1
         }
       },
-      required: ['auth_id', 'client_ids'],
+      required: ['auth_id', 'clients'],
       additionalProperties: false
     }
   },
   {
     name: 'remove_authorized_clients',
-    description: 'Revoke client app access to this API authorization. Clients can no longer request new tokens. Existing tokens remain valid until expiration. Use to immediately cut off API access from compromised or deprecated client apps. Returns success status and x-request-id.',
+    description: 'Revoke OIDC client apps from this API authorization. Provide app_ids — the OIDC app IDs (`app_id` field) as returned by list_authorized_clients, NOT a separate client_id. Clients can no longer request new tokens; existing tokens remain valid until expiration. Returns a results array with per-app ok/error status.',
     inputSchema: {
       type: 'object',
       properties: {
         auth_id: { type: 'number', description: 'The API authorization ID' },
-        client_ids: {
+        app_ids: {
           type: 'array',
           items: { type: 'number' },
-          description: 'Array of client app IDs to revoke'
+          description: 'OIDC app IDs to revoke (the `app_id` values from list_authorized_clients)',
+          minItems: 1
         }
       },
-      required: ['auth_id', 'client_ids'],
+      required: ['auth_id', 'app_ids'],
       additionalProperties: false
     }
   },


### PR DESCRIPTION
## Summary
Fixes #47.

The `/api/2/api_authorizations/{id}/clients` endpoint is a Rails REST resource ([routes](https://github.com/onelogin/core-api/blob/main/config/api2_routes.rb#L67), [controller](https://github.com/onelogin/core-api/blob/main/app/controllers/api/v5/api_auth_clients_controller.rb)):

- `POST /clients` creates **one** association from `{app_id, scopes}` (both required by `required_params`)
- `DELETE /clients/{app_id}` removes one (keyed by the OIDC app's `app_id`, matching what `list_authorized_clients` returns)

The MCP was POSTing `{client_ids: [...]}` to the collection and DELETEing the collection with a body — neither shape the controller accepts, so both returned `400 Missing required field: app_id`.

### Changes
- `add_authorized_clients` now takes `clients: [{app_id, scopes: number[]}]` and POSTs each (scopes are numeric API scope IDs from `list_authorization_scopes`, not value strings)
- `remove_authorized_clients` now takes `app_ids: number[]` and DELETEs each at `/clients/{app_id}`
- Both return a per-item `results` array so partial failures surface cleanly
- Tool descriptions updated to clarify `app_id` vs misleading `client_id`, and that scopes are numeric IDs

## Test plan
Verified end-to-end against the shadow chicken tenant:
- [x] Old `POST /clients` with `{client_ids: [N]}` → `400 Missing required field: app_id` (reproduces #47)
- [x] New `POST /clients` with `{app_id, scopes: [id]}` → `201` with `{app_id, api_auth_id}`
- [x] Old `DELETE /clients` with body → `400`
- [x] New `DELETE /clients/{app_id}` → `204`, association removed (verified via `list_authorized_clients`)