### PR TITLE
fix: authorization scopes use REST resource shape

### DIFF
--- a/lib/tools/api-authorization.js
+++ b/lib/tools/api-authorization.js
@@ -172,43 +172,96 @@ export async function listAuthorizationScopes(api, args) {
 /**
  * Add scopes to an API authorization
  * POST /api/2/api_authorizations/{id}/scopes
+ *
+ * core-api routes /scopes as a standard REST resource: each call creates ONE
+ * scope from {value, description}. To attach multiple scopes in a single tool
+ * call we accept an array and iterate; partial failures surface as per-item
+ * errors. The adapter translates `description` → `label` on the model, so we
+ * pass `description` (not `label`) — the spec explicitly tests that `label`
+ * is stripped as an IDOR guard.
+ *
  * @param {OneLoginApi} api
- * @param {Object} args - {auth_id: number, scopes: string[]}
- * @returns {Promise<Object>}
+ * @param {Object} args - {auth_id: number, scopes: Array<{value: string, description?: string}>}
+ * @returns {Promise<{results: Array<{value: string, status: 'ok'|'error', data?: Object, error?: string}>}>}
  */
 export async function addAuthorizationScopes(api, args) {
   if (!args.auth_id) {
     throw new Error('auth_id is required');
   }
 
-  if (!args.scopes || !Array.isArray(args.scopes)) {
-    throw new Error('scopes array is required');
+  if (!args.scopes || !Array.isArray(args.scopes) || args.scopes.length === 0) {
+    throw new Error('scopes array is required (each item: {value, description?})');
   }
 
-  return await api.post(`/api/2/api_authorizations/${args.auth_id}/scopes`, {
-    scopes: args.scopes
-  });
+  const results = [];
+  for (const scope of args.scopes) {
+    if (!scope.value) {
+      results.push({ value: scope.value ?? null, status: 'error', error: 'value is required on each scope' });
+      continue;
+    }
+    const body = { value: scope.value };
+    if (scope.description !== undefined) body.description = scope.description;
+    try {
+      // api.post returns {success, status, data} and does NOT throw on non-2xx
+      const response = await api.post(
+        `/api/2/api_authorizations/${args.auth_id}/scopes`,
+        body
+      );
+      if (response.success) {
+        results.push({ value: scope.value, status: 'ok', data: response.data });
+      } else {
+        results.push({
+          value: scope.value,
+          status: 'error',
+          error: response.data?.message || `HTTP ${response.status}`
+        });
+      }
+    } catch (err) {
+      results.push({ value: scope.value, status: 'error', error: err.message });
+    }
+  }
+  return { results };
 }
 
 /**
  * Remove scopes from an API authorization
- * DELETE /api/2/api_authorizations/{id}/scopes
+ * DELETE /api/2/api_authorizations/{id}/scopes/{scope_id}
+ *
+ * The route is keyed by the scope's numeric `id` (as returned by
+ * list_authorization_scopes), not the scope value string. One DELETE per
+ * scope; we iterate and report per-item status.
+ *
  * @param {OneLoginApi} api
- * @param {Object} args - {auth_id: number, scopes: string[]}
- * @returns {Promise<Object>}
+ * @param {Object} args - {auth_id: number, scope_ids: number[]}
+ * @returns {Promise<{results: Array<{scope_id: number, status: 'ok'|'error', error?: string}>}>}
  */
 export async function removeAuthorizationScopes(api, args) {
   if (!args.auth_id) {
     throw new Error('auth_id is required');
   }
 
-  if (!args.scopes || !Array.isArray(args.scopes)) {
-    throw new Error('scopes array is required');
+  if (!args.scope_ids || !Array.isArray(args.scope_ids) || args.scope_ids.length === 0) {
+    throw new Error('scope_ids array is required (numeric scope IDs from list_authorization_scopes)');
   }
 
-  return await api.delete(`/api/2/api_authorizations/${args.auth_id}/scopes`, {
-    scopes: args.scopes
-  });
+  const results = [];
+  for (const scopeId of args.scope_ids) {
+    try {
+      const response = await api.delete(`/api/2/api_authorizations/${args.auth_id}/scopes/${scopeId}`);
+      if (response.success) {
+        results.push({ scope_id: scopeId, status: 'ok' });
+      } else {
+        results.push({
+          scope_id: scopeId,
+          status: 'error',
+          error: response.data?.message || `HTTP ${response.status}`
+        });
+      }
+    } catch (err) {
+      results.push({ scope_id: scopeId, status: 'error', error: err.message });
+    }
+  }
+  return { results };
 }
 
 /**
@@ -626,15 +679,24 @@ export const tools = [
   },
   {
     name: 'add_authorization_scopes',
-    description: 'Add OAuth 2.0 scopes to an API authorization. Scopes define granular permissions that client apps can request. Provide array of scope strings (e.g., ["read:users", "write:data"]). Scope naming convention: <action>:<resource>. Duplicate scopes are ignored. Returns success status and x-request-id.',
+    description: 'Add OAuth 2.0 scopes to an existing API authorization. The underlying API creates one scope per call; pass multiple {value, description?} objects to add several in one shot. `value` is the scope identifier (e.g., "contact:read") — no whitespace allowed. `description` is a human-readable label. Naming convention: <action>:<resource>. Returns a results array with per-scope ok/error status; on partial success some scopes will have been created and others not.',
     inputSchema: {
       type: 'object',
       properties: {
         auth_id: { type: 'number', description: 'The API authorization ID' },
         scopes: {
           type: 'array',
-          items: { type: 'string' },
-          description: 'Array of scope strings to add'
+          description: 'Array of scopes to add',
+          items: {
+            type: 'object',
+            properties: {
+              value: { type: 'string', description: 'Scope identifier (e.g., "contact:read") — no whitespace' },
+              description: { type: 'string', description: 'Human-readable description' }
+            },
+            required: ['value'],
+            additionalProperties: false
+          },
+          minItems: 1
         }
       },
       required: ['auth_id', 'scopes'],
@@ -643,18 +705,19 @@ export const tools = [
   },
   {
     name: 'remove_authorization_scopes',
-    description: 'Remove OAuth 2.0 scopes from an API authorization. Client apps can no longer request removed scopes. Existing access tokens with removed scopes remain valid until expiration. Returns success status and x-request-id.',
+    description: 'Remove OAuth 2.0 scopes from an API authorization. Provide scope_ids — the numeric `id` values from list_authorization_scopes (NOT the string scope values). The underlying API deletes one scope per call; we iterate and report per-scope status. Client apps can no longer request removed scopes; existing access tokens remain valid until expiration. Returns a results array with per-scope ok/error status.',
     inputSchema: {
       type: 'object',
       properties: {
         auth_id: { type: 'number', description: 'The API authorization ID' },
-        scopes: {
+        scope_ids: {
           type: 'array',
-          items: { type: 'string' },
-          description: 'Array of scope strings to remove'
+          items: { type: 'number' },
+          description: 'Numeric scope IDs to remove (the `id` values from list_authorization_scopes)',
+          minItems: 1
         }
       },
-      required: ['auth_id', 'scopes'],
+      required: ['auth_id', 'scope_ids'],
       additionalProperties: false
     }
   },


### PR DESCRIPTION
## Summary
- `add_authorization_scopes` and `remove_authorization_scopes` were treating `/api/2/api_authorizations/{id}/scopes` as a bulk endpoint, sending `{scopes: [...]}`. core-api routes it as a standard nested REST resource (`config/api2_routes.rb:65`) — each POST creates one scope from `{value, description}`, each DELETE needs the numeric `scope_id` in the URL.
- Same bug pattern that PR #48 fixed for `/clients`; `/scopes` was overlooked.
- Both handlers now iterate and report per-item status, and inspect `response.success` from the API wrapper so the `status` field reflects reality (the client returns wrapped errors rather than throwing).

Fixes #49

## Schema changes (breaking for anyone using the broken form)
- `add_authorization_scopes`: `scopes` is now `Array<{value, description?}>` (was `string[]`)
- `remove_authorization_scopes`: replaces `scopes: string[]` with `scope_ids: number[]` (numeric IDs from `list_authorization_scopes`)

Returns a `{results: [...]}` envelope with per-item ok/error status, matching the pattern `addAuthorizedClients`/`removeAuthorizedClients` already use.

## Test plan
Verified end-to-end against Chicken-Shadow:
- [x] Create a throwaway API authorization
- [x] `add_authorization_scopes` with two valid scopes + one whitespace value — two 201s, invalid item returns per-item error `"Validation failed: Value may not have any whitespace characters"`
- [x] `list_authorization_scopes` shows the two created with numeric IDs
- [x] `remove_authorization_scopes` with those IDs + one bogus ID — two oks, bogus gets per-item `"The resource with the given id could not be found"`
- [x] Final list is empty
- [x] Cleanup delete OK