### PR TITLE
fix: remove phantom client_app tools

### DIFF
--- a/lib/tools/api-authorization.js
+++ b/lib/tools/api-authorization.js
@@ -370,86 +370,6 @@ export async function listAvailableScopes(api, args = {}) {
 }
 
 /**
- * List client apps (API credentials)
- * GET /api/2/api_authorizations/clients
- * @param {OneLoginApi} api
- * @param {Object} args - Optional filters
- * @returns {Promise<Object>}
- */
-export async function listClientApps(api, args = {}) {
-  const params = {};
-
-  if (args.limit) params.limit = args.limit;
-  if (args.page) params.page = args.page;
-
-  return await api.get('/api/2/api_authorizations/clients', params);
-}
-
-/**
- * Get a specific client app
- * GET /api/2/api_authorizations/clients/{id}
- * @param {OneLoginApi} api
- * @param {Object} args - {client_id: number}
- * @returns {Promise<Object>}
- */
-export async function getClientApp(api, args) {
-  if (!args.client_id) {
-    throw new Error('client_id is required');
-  }
-
-  return await api.get(`/api/2/api_authorizations/clients/${args.client_id}`);
-}
-
-/**
- * Create a new client app
- * POST /api/2/api_authorizations/clients
- * @param {OneLoginApi} api
- * @param {Object} args - Client app configuration
- * @returns {Promise<Object>}
- */
-export async function createClientApp(api, args) {
-  if (!args.name) {
-    throw new Error('name is required');
-  }
-
-  return await api.post('/api/2/api_authorizations/clients', args);
-}
-
-/**
- * Update a client app
- * PUT /api/2/api_authorizations/clients/{id}
- * @param {OneLoginApi} api
- * @param {Object} args - {client_id: number, ...fields to update}
- * @returns {Promise<Object>}
- */
-export async function updateClientApp(api, args) {
-  if (!args.client_id) {
-    throw new Error('client_id is required');
-  }
-
-  const clientId = args.client_id;
-  const updateData = { ...args };
-  delete updateData.client_id;
-
-  return await api.put(`/api/2/api_authorizations/clients/${clientId}`, updateData);
-}
-
-/**
- * Delete a client app
- * DELETE /api/2/api_authorizations/clients/{id}
- * @param {OneLoginApi} api
- * @param {Object} args - {client_id: number}
- * @returns {Promise<Object>}
- */
-export async function deleteClientApp(api, args) {
-  if (!args.client_id) {
-    throw new Error('client_id is required');
-  }
-
-  return await api.delete(`/api/2/api_authorizations/clients/${args.client_id}`);
-}
-
-/**
  * List claims for an API authorization
  * GET /api/2/api_authorizations/{id}/claims
  * @param {OneLoginApi} api
@@ -791,69 +711,6 @@ export const tools = [
     }
   },
   {
-    name: 'list_client_apps',
-    description: 'Get a list of all client apps (API credential pairs) configured for OAuth 2.0 authentication. Client apps use client_id and client_secret to obtain access tokens via client credentials flow. Returns client list with IDs, names, client_id values (secrets redacted), scopes, and x-request-id.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        limit: { type: 'number', description: 'Number of results to return' },
-        page: { type: 'number', description: 'Page number for pagination' }
-      },
-      additionalProperties: false
-    }
-  },
-  {
-    name: 'get_client_app',
-    description: 'Get detailed configuration of a specific client app by ID. Returns complete client definition including name, client_id (for authentication), authorized API authorizations, granted scopes, and configuration. Client secret is not returned for security. Use to review API credential configuration. Returns client data and x-request-id.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        client_id: { type: 'number', description: 'The client app ID' }
-      },
-      required: ['client_id'],
-      additionalProperties: false
-    }
-  },
-  {
-    name: 'create_client_app',
-    description: 'Create a new client app (API credentials) for OAuth 2.0 client credentials flow. Required: name. Returns created client with ID, client_id, and client_secret. IMPORTANT: client_secret is only shown once during creation - store it securely. After creation, use add_authorized_clients to grant access to API authorizations. Returns client credentials and x-request-id.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        name: { type: 'string', description: 'Client app name' },
-        description: { type: 'string', description: 'Client app description' }
-      },
-      required: ['name'],
-      additionalProperties: true
-    }
-  },
-  {
-    name: 'update_client_app',
-    description: 'Update a client app configuration. Can modify name and description. Cannot change client_id or regenerate client_secret via this endpoint. Partial updates supported - only provide fields to change. Returns updated client data (secret redacted) and x-request-id.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        client_id: { type: 'number', description: 'The client app ID to update' },
-        name: { type: 'string', description: 'New name' },
-        description: { type: 'string', description: 'New description' }
-      },
-      required: ['client_id'],
-      additionalProperties: true
-    }
-  },
-  {
-    name: 'delete_client_app',
-    description: 'Permanently delete a client app and revoke its API credentials. WARNING: This immediately invalidates all access tokens obtained by this client. Any applications using these credentials will lose API access. Returns 204 No Content on success and x-request-id.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        client_id: { type: 'number', description: 'The client app ID to delete' }
-      },
-      required: ['client_id'],
-      additionalProperties: false
-    }
-  },
-  {
     name: 'list_authorization_claims',
     description: 'Get all custom claims defined for an API authorization. Claims are user attributes (email, roles, custom fields) included in access tokens as JWT claims. Returns claim list with IDs, names, user attribute mappings, transformations, and x-request-id. Use to audit what user data is exposed in tokens (API v2).',
     inputSchema: {
@@ -929,11 +786,6 @@ export const handlers = {
   add_authorized_clients: addAuthorizedClients,
   remove_authorized_clients: removeAuthorizedClients,
   list_available_scopes: listAvailableScopes,
-  list_client_apps: listClientApps,
-  get_client_app: getClientApp,
-  create_client_app: createClientApp,
-  update_client_app: updateClientApp,
-  delete_client_app: deleteClientApp,
   list_authorization_claims: listAuthorizationClaims,
   add_authorization_claim: addAuthorizationClaim,
   update_authorization_claim: updateAuthorizationClaim,


### PR DESCRIPTION
## Summary
Removes five tools that have never worked: `list_client_apps`, `get_client_app`, `create_client_app`, `update_client_app`, `delete_client_app`.

They call `/api/2/api_authorizations/clients[...]`, which is not a real route. Per `config/api2_routes.rb:65`, `/clients` is nested under a specific authorization (`/api/2/api_authorizations/:api_authorization_id/clients`). The literal `"clients"` in the broken URLs was matching the `:api_authorization_id` slot, so:
- `list_client_apps` → **404** ("resource with the given id could not be found")
- `get/create/update/delete_client_app` → **400** (Rails HTML error fallback, no matching route)

Reproduced end-to-end against Chicken-Shadow — matches the reporter's table exactly.

## Why remove rather than repoint?
There is **no public OneLogin API** (v1 or v2) for managing standalone API credentials. The only `api_credentials` route in core-api is `config/routes.rb:847`, which is an admin-UI session endpoint, not an API. There's nothing to repoint these tools at.

The legitimate nested `/clients` endpoint already has working tools: `list_authorized_clients`, `add_authorized_clients`, `remove_authorized_clients` (fixed in PR #48).

## Impact
- Agents that had learned to call these tools will now get a clear "unknown tool" error instead of a misleading 404/400 from an endpoint that never existed.
- Registry count drops from 152 → 147 tools.
- No schema changes to any remaining tool.

Fixes #50

## Test plan
- [x] Reproduced each failure against Chicken-Shadow (confirmed 404/400 codes match reporter)
- [x] Confirmed `/api/2/api_authorizations/clients` is not a route in `config/api2_routes.rb`
- [x] Confirmed no v1/v2 public API for standalone API credentials exists in core-api
- [x] Module loads; `getToolDefinitions()` returns 147 tools with zero remaining `client_app` references