### PR TITLE
AB#721898: surface OL v2 pagination headers so "how many users" answers in one call

### DIFF
--- a/lib/onelogin-api.js
+++ b/lib/onelogin-api.js
@@ -1,4 +1,36 @@
 /**
+ * Extract OneLogin API v2 pagination metadata from response headers.
+ *
+ * OL v2 list endpoints return the total record count and page/cursor state in
+ * response headers rather than the body (Total-Count, Current-Page, Page-Items,
+ * Before-Cursor, After-Cursor). Surfacing these lets clients answer "how many X"
+ * questions from a single call instead of paging through every record to tally.
+ *
+ * Returns null when no pagination headers are present (single-resource GETs,
+ * mutations, etc.) so the standardized response stays clean for those calls.
+ *
+ * @param {Headers} headers - fetch Response headers (case-insensitive lookup)
+ * @returns {Object|null}
+ */
+function extractPagination(headers) {
+  const pagination = {};
+
+  const totalCount = headers.get('total-count');
+  const currentPage = headers.get('current-page');
+  const pageItems = headers.get('page-items');
+  const beforeCursor = headers.get('before-cursor');
+  const afterCursor = headers.get('after-cursor');
+
+  if (totalCount != null && totalCount !== '') pagination.total_count = Number(totalCount);
+  if (currentPage != null && currentPage !== '') pagination.current_page = Number(currentPage);
+  if (pageItems != null && pageItems !== '') pagination.page_items = Number(pageItems);
+  if (beforeCursor) pagination.before_cursor = beforeCursor;
+  if (afterCursor) pagination.after_cursor = afterCursor;
+
+  return Object.keys(pagination).length > 0 ? pagination : null;
+}
+
+/**
  * OneLogin API Client
  * Handles OAuth2 authentication and API requests
  */
@@ -70,7 +102,9 @@ export class OneLoginApi {
    * Make an authenticated API request
    * @param {string} endpoint - API endpoint (e.g., '/api/2/users')
    * @param {Object} options - Fetch options
-   * @returns {Promise<Object>} Response with {success, request_id, data}
+   * @returns {Promise<Object>} Response with {success, request_id, status, data}, plus a
+   *   `pagination` object ({total_count, current_page, page_items, before_cursor, after_cursor})
+   *   when the endpoint returns OL v2 pagination headers.
    */
   async makeRequest(endpoint, options = {}) {
     // Ensure we have a valid token
@@ -98,6 +132,10 @@ export class OneLoginApi {
 
     const requestId = response.headers.get('x-request-id');
 
+    // OL v2 returns the total record count and page state in headers; surface
+    // them so counting questions can be answered without a full pagination sweep.
+    const pagination = extractPagination(response.headers);
+
     // Parse response body
     let data;
     const contentType = response.headers.get('content-type');
@@ -108,12 +146,14 @@ export class OneLoginApi {
     }
 
     // Return standardized format
-    return {
+    const result = {
       success: response.ok,
       request_id: requestId,
       status: response.status,
       data: data
     };
+    if (pagination) result.pagination = pagination;
+    return result;
   }
 
   /**

--- a/lib/onelogin-api.js
+++ b/lib/onelogin-api.js
@@ -13,17 +13,25 @@
  * @returns {Object|null}
  */
 function extractPagination(headers) {
+  // Parse a numeric header, returning undefined for missing/empty/non-numeric
+  // values so a malformed header never serializes to a misleading null.
+  const num = (value) => {
+    if (value == null || value === '') return undefined;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  };
+
   const pagination = {};
 
-  const totalCount = headers.get('total-count');
-  const currentPage = headers.get('current-page');
-  const pageItems = headers.get('page-items');
+  const totalCount = num(headers.get('total-count'));
+  const currentPage = num(headers.get('current-page'));
+  const pageItems = num(headers.get('page-items'));
   const beforeCursor = headers.get('before-cursor');
   const afterCursor = headers.get('after-cursor');
 
-  if (totalCount != null && totalCount !== '') pagination.total_count = Number(totalCount);
-  if (currentPage != null && currentPage !== '') pagination.current_page = Number(currentPage);
-  if (pageItems != null && pageItems !== '') pagination.page_items = Number(pageItems);
+  if (totalCount !== undefined) pagination.total_count = totalCount;
+  if (currentPage !== undefined) pagination.current_page = currentPage;
+  if (pageItems !== undefined) pagination.page_items = pageItems;
   if (beforeCursor) pagination.before_cursor = beforeCursor;
   if (afterCursor) pagination.after_cursor = afterCursor;
 

--- a/lib/tools/users.js
+++ b/lib/tools/users.js
@@ -271,7 +271,7 @@ export const tools = [
   {
     name: "list_users",
     description:
-      "Get a paginated list of users in a OneLogin account (50 users per page). Can filter by user properties including custom attributes. For efficient syncing between OneLogin and another system, use the updated_since parameter to return only users that changed since last check. Returns user data and x-request-id for log tracing.",
+      "Get a paginated list of users in a OneLogin account (50 users per page). Can filter by user properties including custom attributes. For efficient syncing between OneLogin and another system, use the updated_since parameter to return only users that changed since last check. The response includes a `pagination` object whose `total_count` is the total number of users matching the filters across ALL pages. To answer \"how many users\" questions, make a single call (e.g. limit=1) and read `pagination.total_count` — do NOT page through every user and count them yourself. Returns user data and x-request-id for log tracing.",
     inputSchema: {
       type: "object",
       properties: {


### PR DESCRIPTION
## Problem

Asking the MCP server a counting question — *"how many users are in my OL tenant"* — makes the assistant call `list_users`, receive one page (default 50) with no total, and then page through **every** user and tally them with an ad-hoc script. For large customer tenants this is slow and burns a lot of tokens to produce a number the API already returns for free.

Reported by Marc Maguire. Tracked in AB#721898.

## Root cause

`makeRequest` (`lib/onelogin-api.js`) read only `x-request-id` from the response headers and discarded the rest. OneLogin API v2 returns the total record count and page/cursor state in **headers** (`Total-Count`, `Current-Page`, `Page-Items`, `Before-Cursor`, `After-Cursor`), so the standardized response shape (`{ success, request_id, status, data }`) never carried a total. The model had no count to read — brute-force pagination was its only option.

## Fix

1. **API client** — add `extractPagination()` and surface a `pagination` object on the response (`total_count`, `current_page`, `page_items`, `before_cursor`, `after_cursor`). It is attached **only when pagination headers are present**, so single-resource GETs and mutations are unchanged. This benefits every paginated `list_*` tool (apps, events, roles, groups…), not just users.
2. **`list_users` description** — instruct the model to answer "how many users" from a single call (e.g. `limit=1`) by reading `pagination.total_count`, rather than paging through everyone to count.

## Testing

- `node --check` on both edited files — passes.
- Validated `extractPagination` against a real `Headers` object:
  - list page (mixed-case header names, empty `before-cursor`) → `{total_count:12345, current_page:1, page_items:50, after_cursor:"abc123"}` (empty cursor correctly omitted, numbers parsed).
  - single-resource response (no pagination headers) → `null` (no extra noise).

No new dependencies. Backward compatible — existing consumers of `data` / `request_id` are untouched.