### PR TITLE
chore: bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,9 +10,9 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,17 +17,17 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name || github.ref }}
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
       - name: Setup Node.js for npm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Why

The publish run for v1.0.19 surfaced a deprecation annotation: `actions/checkout@v4`, `actions/setup-node@v4`, and `oven-sh/setup-bun@v1` run on Node.js 20, which GitHub forces to Node 24 on runners starting **2026-06-16** (and removes Node 20 on 2026-09-16). This bumps the pins ahead of that so the annotation goes away and the workflows keep working.

## Changes

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `oven-sh/setup-bun` | v1 | v2 |

Across both `ci-cd.yml` and `publish.yml`. All three new majors accept the same inputs already in use (`ref`/`fetch-depth`, `node-version`/`registry-url`, `bun-version`), so no other changes are needed.

`node-version: '20'` in the publish job is intentionally left as-is — that's the Node runtime used to run `npm publish`, not the action runtime the deprecation refers to.

## Risk / rollback

Low. CI on this PR exercises the bumped `checkout`/`setup-bun` directly (`node --check` + `npm pack --dry-run`). The publish path is only exercised on a release event; if it ever regressed, revert this commit. No functional code touched.